### PR TITLE
Precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ chrony
 Version
 -------
 
+* `1.2.2` --- remove ubuntu precise from testing
 * `1.2.1` --- fix lint problem
 * `1.2.0` --- added ubuntu focal, 20.04
 * `1.1.2` --- tested with Ansible 2.9.11
@@ -25,7 +26,6 @@ This role is limited to
 * Ubuntu 18.04 - Bionic
 * Ubuntu 16.04 - Xenial
 * Ubuntu 14.04 - Trusty
-* Ubuntu 12.04 - Precise
 * CentOS 8
 * CentOS 7
 * CentOS 6

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ chrony
 Version
 -------
 
-* `1.2.2` --- remove ubuntu precise from testing
+* `1.3.0` --- remove ubuntu precise from testing
 * `1.2.1` --- fix lint problem
 * `1.2.0` --- added ubuntu focal, 20.04
 * `1.1.2` --- tested with Ansible 2.9.11

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -9,7 +9,6 @@ Vagrant.configure("2") do |config|
     { :name => "bionic", :box => "ubuntu/bionic64" },
     { :name => "xenial", :box => "ubuntu/xenial64" },
     { :name => "trusty", :box => "ubuntu/trusty64" },
-    { :name => "precise", :box => "ubuntu/precise64" },
     { :name => "centos8", :box => "centos/8" },
     { :name => "centos7", :box => "centos/7" },
     { :name => "centos6", :box => "centos/6" },


### PR DESCRIPTION
Hi!

I'd like to contribute bugfix.

Ubuntu isn't publishing the old Precise image on Vagrant Cloud anymore.

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [ ] I have read and accepted both license and code of conduct.
* [x] I have previously accepted and still accept both license and code of conduct.
